### PR TITLE
fix scroll & fix namespaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,11 @@
     <!-- import the webpage's stylesheet -->
     <link rel="stylesheet" href="style.css" />
     <!-- import the latest version of hydra synth-->
+    <script src="./p5.min.js"></script>
+    <script src="./p5.dom.min.js"></script>
+
     <script src="https://unpkg.com/hydra-synth"></script>
-    
+
     </head>
   
   <body>
@@ -60,7 +63,7 @@
 
     </script>
 
-
+    <div id="p5container"></div>
     
     <div id="main">
       
@@ -71,7 +74,6 @@
      
       <code>
       
-s0.initImage("inari.png")
 
 
 
@@ -81,7 +83,7 @@ src(s0)
       .color(0,0.1,0,0)
       .scale(0.8,[1.25],()=>window.innerWidth/window.innerHeight))
     .contrast(2).luma(0.25, 0.25)
-    .modulate(o0, () => 0.062)
+    .modulate(src(o0), () => 0.062)
     //.luma(0.5, 0.1)
     .scale(0.99, 0.99)
     .pixelate(100*10, 50*10)
@@ -97,7 +99,6 @@ src(s0)
       <div class="spacer"></div>
       
       <code>
-s0.initImage("inari.png")
 
 
 
@@ -107,7 +108,7 @@ src(s0)
       .color(0,0.1,0,0)
       .scale(0.5,[1.15],()=>window.innerWidth/window.innerHeight))
     .contrast(1.5).luma(0.35, 0.15)
-    .modulate(o0, () => 0.12)
+    .modulate(src(o0), () => 0.12)
     //.luma(0.5, 0.1)
     .scale(0.99, 0.99)
     //.pixelate(100*10, 50*10)
@@ -137,7 +138,7 @@ src(s0)
       <code>
 src(o0)
     //.modulateHue(src(o0)
-    .scale(11),2)
+    //.scale(11),2)
     .layer(src(o0).rotate(1.57)
     .mask(shape(4,0.3,1e-6)).scale(1.5,.006,0.2), 01)
 .out()  
@@ -171,6 +172,7 @@ src(o0)
       
     </div>
     
+    <script src="./sketch.js"></script>
     <script src="./script.js"></script>
   
   </body>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
   
   <body>
     <script language=javascript>
-     var speed=0.025
-    var downspeed= 0.025
+     var speed=2
+    var downspeed= 2
     var stopspeed= 0
     var currentpos=0
     var alt = 0
@@ -32,32 +32,22 @@
     speed = downspeed
     }
     function scrollwindow(){
-    if (document.all) {
-    temp=document.body.scrollDown;
-    }
-    else {
     temp=window.pageYOffset;
-    }
-    if (alt==0) {
-    alt=1;
-    curpos2 = temp;
-    }
-    else {
-    alt=0;
-    curpos1 = temp;
-    }
-    if ((curpos1==curpos2) && (speed > 0)) {
-    currentpos = 0;
-    curpos1 = 200;
-    }
-    else {
-    if (document.all) {
-    currentpos=document.body.scrollDown+speed;
-    }
-    else {
+    // if (alt==0) {
+    // alt=1;
+    // curpos2 = temp;
+    // }
+    // else {
+    // alt=0;
+    // curpos1 = temp;
+    // }
+    // if ((curpos1==curpos2) && (speed > 0)) {
+    // currentpos = 0;
+    // curpos1 = 200;
+    // }
+    // else {
     currentpos=window.pageYOffset+speed;
-    }
-    }
+    // }
     if (speed > 0) { window.scrollTo(0,currentpos); }
     setTimeout("scrollwindow()", 12);
     }
@@ -65,8 +55,8 @@
     setTimeout("scrollwindow()", 12)
     }
     window.onload=initialize
-    // document.onmousedown = goup;
-    // document.ondblclick = godown;
+    document.onmousedown = goup;
+    document.ondblclick = godown;
 
     </script>
 

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-let hydra, hydraCanvas;
+var hydra, hydraCanvas;
 hydraCanvas = document.createElement("canvas");
 hydraCanvas.width = window.innerWidth;
 hydraCanvas.height = window.innerHeight;
@@ -9,6 +9,7 @@ hydra = new Hydra({
   detectAudio: false,
   width: window.innerWidth,
   height: window.innerHeight,
+  makeGlobal: false
 });
 
 document.body.appendChild(hydraCanvas);
@@ -18,9 +19,13 @@ const codeblocks = document.querySelectorAll("code");
 
 let initialized = false;
 
+hydra.eval(`s0.initImage("inari.png")`)
+
+
 for(const cb of codeblocks) {
   if(initialized == false) {
-    eval(cb.textContent);
+    console.log(`{${cb.textContent}}`);
+    hydra.eval(`${cb.textContent}`);
     initialized = true;
   }
 
@@ -31,9 +36,9 @@ for(const cb of codeblocks) {
       // solid(0,0,0,0).out(o1)
       // solid(0,0,0,0).out(o2)
       // solid(0,0,0,0).out(o3)
-      render(o0);
+      // render(o0);
       setTimeout(()=>{
-        eval(cb.textContent)
+        hydra.eval(`${cb.textContent}`);
       }, 60);
     }
   }, { threshold: [0.07] });

--- a/sketch.js
+++ b/sketch.js
@@ -6,18 +6,18 @@ function preload() {
 }
 
 function setup() {
-  createCanvas(1024, 512);
+  createCanvas(1024, 512).parent("#p5container");
 
+  // makeDithered(kitten, 2);
 }
 
 function draw() {
 
 tamango++;
-   makeDithered(kitten, 2);
 
   image(kitten, 0, 0);
   // Apply gray filter to the whole canvas
-  filter(PINK);
+  // filter(PINK);
 
 if (tamango >= 106) {
 	tamango = 1;

--- a/style.css
+++ b/style.css
@@ -119,6 +119,14 @@ canvas {
     text-align: right;
 }
 
+#p5container {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index:2;
+}
 
 .spacer {
 /* width: 512px; */


### PR DESCRIPTION
1. fixes the scroll issue (perhaps... I didn't get what you wanted to do with `alt` variable so I commented it out
2. fixes hydra - p5 namespace conflict
    * however you always have to do `src(o0)` for example you cannot do `modulate(o0)` but you have to do `modulate(src(o0))` because of hydra bug
    * I skipped dithering because this takes too much time to process
